### PR TITLE
only connect whitelisted users

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -36,6 +36,7 @@ class Bot {
     this.nickname = options.nickname;
     this.ircStatusNotices = options.ircStatusNotices || {};
     this.commandCharacters = options.commandCharacters || [];
+    this.userWhitelist = options.userWhitelist || [];
     this.slackChannels = _.keys(options.channelMapping);
     this.ircChannels = _.values(options.channelMapping);
     this.muteSlackbot = options.muteSlackbot || false;
@@ -273,8 +274,13 @@ class Bot {
   isCommandMessage(message) {
     return this.commandCharacters.indexOf(message[0]) !== -1;
   }
+  
+  isAllowed(user) {
+    return this.userWhitelist.indexOf(user.name) !== -1;
+  }
 
   connectNewClient(user) {
+    if (!(this.isAllowed(user))) return;
     if (!(user.id in this.ircClients)) {
       const userOptions = Object.assign({}, this.ircOptions);
       userOptions.userName = user.name;


### PR DESCRIPTION
Hi, I have a problem with the automatic connection of active users.
I see users connecting to irc, though they are not in the configured private channel.

Kind of a workaround is this user whitelist, where I can limit the number of users that go to irc, rather  than all of my slack team.

But I see the whitelist approach as generally beneficial to be able to control, who goes to irc.